### PR TITLE
Empty page on GetNextPage

### DIFF
--- a/projects/ngrx-data-pagination/src/lib/pagination/store-interfaces/store-pagination-context.ts
+++ b/projects/ngrx-data-pagination/src/lib/pagination/store-interfaces/store-pagination-context.ts
@@ -83,10 +83,16 @@ export class StorePaginationContext<Entity extends AnyEntity> {
       throw new Error('bad page in getNextPageP');
     }
 
-    this.dispatchers.GetNextPageSuccess(
-      page.map(({ id }) => id),
-      this.pageIterator.done,
-    );
+    const entityIds = page.map(({ id }) => id);
+
+    if (!entityIds.length) {
+      this.dispatchers.GetNextPageEmpty();
+    } else {
+      this.dispatchers.GetNextPageSuccess(
+        entityIds,
+        this.pageIterator.done,
+      );
+    }
 
     return page;
   }

--- a/projects/ngrx-data-pagination/src/lib/pagination/store/actions.ts
+++ b/projects/ngrx-data-pagination/src/lib/pagination/store/actions.ts
@@ -4,6 +4,7 @@ export enum PaginationActionType {
   RESET_PAGINATION_STATE = '[mb-Pagination] Reset Pagination State',
   GET_NEXT_PAGE = '[mb-Pagination] Get Next Page',
   GET_NEXT_PAGE_SUCCESS = '[mb-Pagination] Get Next Page Success',
+  GET_NEXT_PAGE_EMPTY = '[mb-Pagination] Get Next Page Empty',
   PREV_PAGE = '[mb-Pagination] Prev Page',
   NEXT_PAGE = '[mb-Pagination] Next Page',
 }
@@ -35,6 +36,12 @@ export class GetNextPageSuccess implements PaginationActionT {
     public done: boolean,
   ) {}
 }
+export class GetNextPageEmpty implements PaginationActionT {
+  readonly type = T.GET_NEXT_PAGE_EMPTY;
+  constructor(
+    public contextId: string
+  ) {}
+}
 export class PrevPage implements PaginationActionT {
   readonly type = T.PREV_PAGE;
   constructor(public contextId: string) {}
@@ -48,6 +55,7 @@ export type PaginationAction =
   | ResetPaginationState
   | GetNextPage
   | GetNextPageSuccess
+  | GetNextPageEmpty
   | PrevPage
   | NextPage;
 
@@ -56,6 +64,7 @@ export const makeActionCreators = (contextId: string) => ({
   GetNextPage: () => new GetNextPage(contextId),
   GetNextPageSuccess: (entityIds: EntityId[], done: boolean) =>
     new GetNextPageSuccess(contextId, entityIds, done),
+  GetNextPageEmpty: () => new GetNextPageEmpty(contextId),
   PrevPage: () => new PrevPage(contextId),
   NextPage: () => new NextPage(contextId),
 });
@@ -71,6 +80,7 @@ export const makeDispatchers = (
     GetNextPage: () => dispatch(actionCreators.GetNextPage()),
     GetNextPageSuccess: (entityIds: EntityId[], done: boolean) =>
       dispatch(actionCreators.GetNextPageSuccess(entityIds, done)),
+    GetNextPageEmpty: () => dispatch(actionCreators.GetNextPageEmpty()),
     PrevPage: () => dispatch(actionCreators.PrevPage()),
     NextPage: () => dispatch(actionCreators.NextPage()),
   };

--- a/projects/ngrx-data-pagination/src/lib/pagination/store/actions.ts
+++ b/projects/ngrx-data-pagination/src/lib/pagination/store/actions.ts
@@ -56,7 +56,6 @@ export const makeActionCreators = (contextId: string) => ({
   GetNextPage: () => new GetNextPage(contextId),
   GetNextPageSuccess: (entityIds: EntityId[], done: boolean) =>
     new GetNextPageSuccess(contextId, entityIds, done),
-  GetPrevPage: () => new PrevPage(contextId),
   PrevPage: () => new PrevPage(contextId),
   NextPage: () => new NextPage(contextId),
 });

--- a/projects/ngrx-data-pagination/src/lib/pagination/store/reducer.spec.ts
+++ b/projects/ngrx-data-pagination/src/lib/pagination/store/reducer.spec.ts
@@ -1,6 +1,7 @@
 import {
   GetNextPage,
   GetNextPageSuccess,
+  GetNextPageEmpty,
   NextPage,
   PrevPage,
   ResetPaginationState,
@@ -49,6 +50,52 @@ describe('paginationContextReducer', () => {
       ...defaultPaginationContextState,
       pages: [[0, 1, 2]],
       currentPage: 0,
+    });
+  });
+
+  it('GetNextPageEmptyBeforeFirstPage', () => {
+    const initialState: PaginationContextState = {
+      ...defaultPaginationContextState,
+    };
+
+    const state = paginationContextReducer(
+      initialState,
+      new GetNextPage('a context id'),
+    );
+
+    const action = new GetNextPageEmpty('a context id');
+
+    const newState = paginationContextReducer(state, action);
+
+    expect(newState).toEqual({
+      ...defaultPaginationContextState,
+      pages: [[]],
+      currentPage: 0,
+      done: true,
+    });
+  });
+
+  it('GetNextPageEmptyAfterFirstPage', () => {
+    const initialState: PaginationContextState = {
+      ...defaultPaginationContextState,
+      pages: [[0, 1, 2]],
+      currentPage: 0,
+    };
+
+    const state = paginationContextReducer(
+      initialState,
+      new GetNextPage('a context id'),
+    );
+
+    const action = new GetNextPageEmpty('a context id');
+
+    const newState = paginationContextReducer(state, action);
+
+    expect(newState).toEqual({
+      ...defaultPaginationContextState,
+      pages: [[0, 1, 2]],
+      currentPage: 0,
+      done: true,
     });
   });
 

--- a/projects/ngrx-data-pagination/src/lib/pagination/store/reducer.ts
+++ b/projects/ngrx-data-pagination/src/lib/pagination/store/reducer.ts
@@ -34,6 +34,19 @@ export function paginationContextReducer(
         progressionCancelled: false,
       };
 
+    case T.GET_NEXT_PAGE_EMPTY:
+      const isFirstFetchedPage = (state.pages.length === 0);
+      return {
+        ...state,
+        loadingNewPage: false,
+        pages: isFirstFetchedPage ? [[]] : [...state.pages],
+        currentPage: state.progressionCancelled && !isFirstFetchedPage
+          ? state.currentPage
+          : state.currentPage + 1,
+        done: true,
+        progressionCancelled: false,
+      };
+
     case T.PREV_PAGE:
       return {
         ...state,


### PR DESCRIPTION
Hi Max!

Thanks again for this library, it helped me so much! :tada: 

## Backstory

Using DynamoDB, the next page identifier is given by a `lastEvaluatedKey`.
If you limit a DynamoDB query by `5` and the full dataset is `5`, `lastEvaluatedKey` will not be null (this is a DynamoDB limitation).

Hence, as an end-user of the library, you can't tell if a next page is really available or not, so you can't give a trustable `done` parameter.
You are allowed to request the next page but it will return an empty result, add this empty page and move the page number to it.

## How to reproduce

Giving an empty page after the first page has been loaded with `done` parameter set to `true` gives a "ghost last page". 

## Solution

When receiving an empty page, we should :
* Put `done` to `true` ;
* Increment `pageNumber` only if it's the first page ;
* Add the page to `pages` only if it's the first page.

We have to keep in mind that an empty first page is valid but **an empty page loaded after the first one is not**.
This last statement is subject to discuss and may invalidate this PR.

## References

* https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-response-LastEvaluatedKey

Note : I was unable to setup the test suite, can you check if tests are passing please?
