### PR TITLE
Remove deleted entities from page selector

### DIFF
--- a/projects/ngrx-data-pagination/src/lib/pagination/store-interfaces/ngrx/selectors.ts
+++ b/projects/ngrx-data-pagination/src/lib/pagination/store-interfaces/ngrx/selectors.ts
@@ -89,7 +89,12 @@ const advancedPaginationSelectors = <Entity>(
         if (!ids || !entityMap) {
           return null;
         }
-        return ids.map(id => entityMap[id]);
+        return ids.reduce((a, id) => {
+          if (id in entityMap) {
+            a.push(entityMap[id]);
+          }
+          return a;
+        }, []);
       },
     ),
   };


### PR DESCRIPTION
## The bug
When an entity is removed (using `ngrx-data` for example), `ngrx-data-pagination` does not handle it well as it try to fetch removed entities from cache but is unable to get them.

## Solution
We must check if the entity still exists in the cache before trying to fetch it.